### PR TITLE
Gcode arc resolution improvement

### DIFF
--- a/config/K1_CR4CU220812S12/printer.cfg
+++ b/config/K1_CR4CU220812S12/printer.cfg
@@ -49,7 +49,7 @@ timeout: 99999999
 path: /usr/data/printer_data/gcodes
 
 [gcode_arcs]
-resolution: 1.0
+resolution: 0.1
 
 [temperature_sensor mcu_temp]
 sensor_type: temperature_mcu

--- a/config/K1_MAX_CR4CU220812S12/printer.cfg
+++ b/config/K1_MAX_CR4CU220812S12/printer.cfg
@@ -49,7 +49,7 @@ timeout: 99999999
 path: /usr/data/printer_data/gcodes
 
 [gcode_arcs]
-resolution: 1.0
+resolution: 0.1
 
 [temperature_sensor mcu_temp]
 sensor_type: temperature_mcu


### PR DESCRIPTION
This pull request aims to improve the quality of the arcs generated by the gcode_arcs configuration. The current resolution of 1.0 is not sufficient to produce smooth and accurate curves, especially for small radii. Therefore, it is recommended to lower the resolution to 0.1, which will result in more segments per arc and less deviation from the desired shape. The CPU of the motherboard can handle this resolution without any problem, as it has been tested on various models and scenarios. This change will enhance the performance and appearance of the printed objects, as well as reduce the file size and the printing time.