### PR TITLE
Fix for M106 macro

### DIFF
--- a/config/K1_CR4CU220812S12/gcode_macro.cfg
+++ b/config/K1_CR4CU220812S12/gcode_macro.cfg
@@ -190,6 +190,9 @@ gcode:
   {% if value >= 255 %}
     {% set value = 255 %}
   {% endif %}
+  {% if params.P is defined and params.P|int == 3 %}
+    {% set fan = 1 %}
+  {% endif %}
   SET_PIN PIN=fan{fan} VALUE={value}
 
 [gcode_macro M107]

--- a/config/K1_CR4CU220812S12/gcode_macro.cfg
+++ b/config/K1_CR4CU220812S12/gcode_macro.cfg
@@ -178,13 +178,43 @@ gcode:
   {% endif %}
   {% if tmp > 0 %}
     {% if fan == 0 %}
-      {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
+      {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
+      {% if printer['gcode_macro Qmode'].flag | int == 1 %}
+        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan0_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan0_min + value}
+        {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2  %}
+          {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2 %}
+        {% else %}
+          {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + value %}
+        {% endif %}
+      {% else %}
+        {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + value %}
+      {% endif %}
     {% endif %}
     {% if fan == 1 %}
-      {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
+      {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
+      {% if printer['gcode_macro Qmode'].flag | int == 1 %}
+        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan1_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan1_min + value}
+        {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2  %}
+          {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2 %}
+        {% else %}
+          {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + value %}
+        {% endif %}
+      {% else %}
+        {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + value %}
+      {% endif %}
     {% endif %}
     {% if fan == 2 %}
-      {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
+      {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
+      {% if printer['gcode_macro Qmode'].flag | int == 1 %}
+        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan2_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan2_min + value}
+        {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2  %}
+          {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2 %}
+        {% else %}
+          {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + value %}
+        {% endif %}
+      {% else %}
+        {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + value %}
+      {% endif %}
     {% endif %}
   {% endif %}
   {% if value >= 255 %}

--- a/config/K1_CR4CU220812S12/gcode_macro.cfg
+++ b/config/K1_CR4CU220812S12/gcode_macro.cfg
@@ -178,43 +178,13 @@ gcode:
   {% endif %}
   {% if tmp > 0 %}
     {% if fan == 0 %}
-      {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
-      {% if printer['gcode_macro Qmode'].flag | int == 1 %}
-        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan0_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan0_min + value}
-        {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2  %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2 %}
-        {% else %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + value %}
-        {% endif %}
-      {% else %}
-        {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + value %}
-      {% endif %}
+      {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
     {% endif %}
     {% if fan == 1 %}
-      {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
-      {% if printer['gcode_macro Qmode'].flag | int == 1 %}
-        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan1_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan1_min + value}
-        {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2  %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2 %}
-        {% else %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + value %}
-        {% endif %}
-      {% else %}
-        {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + value %}
-      {% endif %}
+      {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
     {% endif %}
     {% if fan == 2 %}
-      {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
-      {% if printer['gcode_macro Qmode'].flag | int == 1 %}
-        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan2_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan2_min + value}
-        {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2  %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2 %}
-        {% else %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + value %}
-        {% endif %}
-      {% else %}
-        {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + value %}
-      {% endif %}
+      {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
     {% endif %}
   {% endif %}
   {% if value >= 255 %}

--- a/config/K1_MAX_CR4CU220812S12/gcode_macro.cfg
+++ b/config/K1_MAX_CR4CU220812S12/gcode_macro.cfg
@@ -190,6 +190,9 @@ gcode:
   {% if value >= 255 %}
     {% set value = 255 %}
   {% endif %}
+  {% if params.P is defined and params.P|int == 3 %}
+    {% set fan = 1 %}
+  {% endif %}
   SET_PIN PIN=fan{fan} VALUE={value}
 
 [gcode_macro M107]


### PR DESCRIPTION
The modification proposed in this pull request is safe and allows to manage correctly the M106 command on other slicers than Creality Print. Because the macro uses the notation M106 P1 instead of M106 P3 (which is the standard).

The idea comes from here : https://github.com/Guilouz/Creality-K1-and-K1-Max/wiki/Improve-Fans-Control