### PR TITLE
fix: Fixing timers on GD32

### DIFF
--- a/src/gd32/Makefile
+++ b/src/gd32/Makefile
@@ -46,7 +46,7 @@ src-y += generic/armcm_boot.c generic/armcm_irq.c
 src-y += generic/armcm_reset.c generic/crc16_ccitt.c
 
 src-$(CONFIG_MACH_GD32F30X) += gd32/gd32f30x.c gd32/gd32f30x_gpio.c
-src-$(CONFIG_MACH_GD32F30X) += generic/armcm_timer.c
+src-$(CONFIG_MACH_GD32F30X) += gd32/gd32e23x_timer.c generic/timer_irq.c
 # pwm-src-$(CONFIG_MACH_GD32F30X) := gd32/hard_pwm.c
 
 src-$(CONFIG_MACH_GD32E23X) += gd32/gd32e23x.c gd32/gd32e23x_gpio.c  


### PR DESCRIPTION
Fixes the correct logic of the Klipper timer on GD32 series chips